### PR TITLE
HELM-22  Enhancing Tracking Usage of XWiki Helm on ActiveInstalls

### DIFF
--- a/charts/xwiki/templates/initialization-configmaps.yaml
+++ b/charts/xwiki/templates/initialization-configmaps.yaml
@@ -54,6 +54,12 @@ data:
     export JAVA_OPTS=" -javaagent:/usr/local/xwiki/data/glowroot/glowroot-${GLOWROOT_VERSION}/glowroot.jar ${JAVA_OPTS}"
     {{- end }}
 
+    # Replace the platform provenance to keep track of the image
+    sed -i 's/<id>org.xwiki.platform:xwiki-platform-distribution-war/<id>org.xwiki.contrib:xwiki-platform-distribution-helm-docker/' \
+      /usr/local/tomcat/webapps/ROOT/META-INF/extension.xed
+    sed -i 's/<id>org.xwiki.platform:xwiki-platform-distribution-docker/<id>org.xwiki.contrib:xwiki-platform-distribution-helm-docker/' \
+      /usr/local/tomcat/webapps/ROOT/META-INF/extension.xed
+
     exec /usr/local/bin/docker-entrypoint.sh xwiki
   glowroot.properties: |
     {{- with .Values.glowroot.properties }}


### PR DESCRIPTION
## Description

This PR aims to improve the tracking of the Image used within Helm.

For now, the `<id>` tag is replaced in the `initScript`. The name was chosen according to the proposed one in the issue : `org.xwiki.contrib:xwiki-platform-distribution-helm-docker`.

## Improvement

Other improvement could be made to improve the tracking, that are not covered in this PR like:
- [ ] Add extra `LABEL` in the Dockerfile of the XWiki images with the information
- [ ] Add extra `labels` to the XWiki Deployement/Pod with the information 
- [ ] Verify before the startup the name of the docker image and adjust the initScript based on the name