### PR TITLE
HELM-37: Remove duplicate extension reporitories

### DIFF
--- a/charts/xwiki/Chart.yaml
+++ b/charts/xwiki/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: XWiki is a free wiki software platform written in Java with a design emphasis on extensibility. XWiki is an enterprise wiki. It includes WYSIWYG editing, OpenDocument based document import/export, semantic annotations and tagging, and advanced permissions management.
 name: xwiki
-version: 1.2.0-Beta.4
+version: 1.2.0-Beta.5
 type: application
 keywords:
 - xwiki

--- a/charts/xwiki/templates/initialization-configmaps.yaml
+++ b/charts/xwiki/templates/initialization-configmaps.yaml
@@ -58,10 +58,21 @@ data:
     {{- end }}
 
     # Replace all values from keys defineded on customConfigs
+    # If we detect extension, we loop over the array and add them
     {{- range $file, $values := .Values.customConfigs }}
       {{- range $key, $value := $values }}
-        # TODO review/manage extensions
-        xwiki_replace_or_add "/usr/local/xwiki/data/{{ $file }}" {{ $key }} {{ $value }}
+        {{ if eq (toString $key) "extension.repositories" }}
+          {{- range $property := $value }}
+            if [ "${alreadyAddExtensionRepo}" == "true" ]; then
+              echo "{{ $key }}={{ $property }}" >> /usr/local/xwiki/data/{{ $file }}
+            else
+              xwiki_replace_or_add "/usr/local/xwiki/data/{{ $file }}" {{ $key }} {{ $property }}
+              alreadyAddExtensionRepo="true"
+            fi
+          {{- end }}
+        {{ else }}
+          xwiki_replace_or_add "/usr/local/xwiki/data/{{ $file }}" {{ $key }} {{ $value }}
+        {{- end }}
       {{- end }}
     {{- end }}
 

--- a/charts/xwiki/tests/initialization-configmaps_test.yaml
+++ b/charts/xwiki/tests/initialization-configmaps_test.yaml
@@ -1,0 +1,23 @@
+suite: test initialization configmaps
+templates:
+  - initialization-configmaps.yaml
+tests:
+  - it: should apply correct changes to initialization-configmaps.yaml
+    set:
+      customConfigs:
+        xwiki.properties:
+          extension.repositories.privatemavenid.http.headers.headername: headervalue
+          extension.repositories: 
+          - "xwiki-extensions-xxx:maven:http://172.25.128.67:8081/repository/xwiki/"
+          - store.xwiki.com:xwiki:https://store.xwiki.com/xwiki/rest/
+          core.defaultDocumentSyntax: xwiki/2.1
+    asserts:
+      - matchRegex:
+          path: data["entrypoint"]
+          pattern: "extension.repositories=xwiki-extensions-xxx:maven:http://172.25.128.67:8081/repository/xwiki/"
+      - matchRegex:
+          path: data["entrypoint"]
+          pattern: "extension.repositories=store.xwiki.com:xwiki:https://store.xwiki.com/xwiki/rest/"
+      - matchRegex:
+          path: data["entrypoint"]
+          pattern: "core.defaultDocumentSyntax xwiki/2.1"

--- a/charts/xwiki/values.yaml
+++ b/charts/xwiki/values.yaml
@@ -320,7 +320,7 @@ glowroot:
     log.dir: /usr/local/xwiki/data/glowroot/log
     tmp.dir: /usr/local/xwiki/data/glowroot/tmp
 
-logback: 
+logback:
   enabled: false
 #  customConfiguration: |
 #    <appender name="stdout" class="ch.qos.logback.core.ConsoleAppender">


### PR DESCRIPTION
## Objective
This MR address the issue concerning duplicate Extension repositories.

To address that, I have added the possibility to add multiple.
Due to Yaml Templating, For adding several extensions you should add them in an array instead of copying the value several times.

## Tests

You can try the correct behavior with the following values:
```yaml
customConfigs:
  xwiki.properties:
    extension.repositories.privatemavenid.http.headers.headername: headervalue
    extension.repositories: 
    - "xwiki-extensions-xxx:maven:http://172.25.128.67:8081/repository/xwiki/"
    - store.xwiki.com:xwiki:https://store.xwiki.com/xwiki/rest/
    core.defaultDocumentSyntax: xwiki/2.1
# Properties to be passed to Java process with -D parameters using JAVA_OPTS
properties:
```

In the container you can then see the file and the modified lines:

```
$ cat /usr/local/xwiki/data/xwiki.properties | grep extension.repo
# extension.repositories = privatemavenid:maven:http://host.com/private/maven/
# extension.repositories.privatemavenid.auth.user = someuser
# extension.repositories.privatemavenid.auth.password = thepassword
# extension.repositories.privatemavenid.http.headers.headername = headervalue
# extension.repositories = maven-local:maven:file://${sys:user.home}/.m2/repository
# extension.repositories = maven-xwiki-snapshot:maven:https://nexus.xwiki.org/nexus/content/groups/public-snapshots
# extension.repositories = maven-xwiki:maven:https://nexus.xwiki.org/nexus/content/groups/public
# extension.repositories = store.xwiki.com:xwiki:https://store.xwiki.com/xwiki/rest/
# extension.repositories = extensions.xwiki.org:xwiki:https://extensions.xwiki.org/xwiki/rest/
extension.repositories=xwiki-extensions-xxx:maven:http://172.25.128.67:8081/repository/xwiki/
#-# The default is extension/repository in whatever is the general persistent directory.
# extension.localRepository=extension/repository
extension.repositories=store.xwiki.com:xwiki:https://store.xwiki.com/xwiki/rest/
extension.repositories.privatemavenid.http.headers.headername=headervalue
```
As we can see, we have all lines at expected and also the other from the custom config