### PR TITLE
HELM38: Value to download glowroot jar from url

### DIFF
--- a/charts/xwiki/Chart.yaml
+++ b/charts/xwiki/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: XWiki is a free wiki software platform written in Java with a design emphasis on extensibility. XWiki is an enterprise wiki. It includes WYSIWYG editing, OpenDocument based document import/export, semantic annotations and tagging, and advanced permissions management.
 name: xwiki
-version: 1.2.0-Beta.5
+version: 1.2.0-Beta.6
 type: application
 keywords:
 - xwiki

--- a/charts/xwiki/templates/initialization-configmaps.yaml
+++ b/charts/xwiki/templates/initialization-configmaps.yaml
@@ -85,9 +85,9 @@ data:
 
     {{- if .Values.glowroot.enabled }}
     mkdir -p /usr/local/xwiki/data/glowroot
-    GLOWROOT_VERSION="0.14.0"
+    GLOWROOT_VERSION={{ .Values.glowroot.version | quote }}
     if ! [ -d "/usr/local/xwiki/data/glowroot/glowroot-${GLOWROOT_VERSION}" ]; then
-      wget -O  /tmp/glowroot-${GLOWROOT_VERSION}-dist.zip https://github.com/glowroot/glowroot/releases/download/v${GLOWROOT_VERSION}/glowroot-${GLOWROOT_VERSION}-dist.zip
+      wget -O  /tmp/glowroot-${GLOWROOT_VERSION}-dist.zip {{ .Values.glowroot.url }}
       unzip /tmp/glowroot-${GLOWROOT_VERSION}-dist.zip -d /usr/local/xwiki/data/glowroot/
       rm -f /tmp/glowroot-${GLOWROOT_VERSION}-dist.zip
       mv /usr/local/xwiki/data/glowroot/glowroot /usr/local/xwiki/data/glowroot/glowroot-${GLOWROOT_VERSION}

--- a/charts/xwiki/tests/initialization-configmaps_test.yaml
+++ b/charts/xwiki/tests/initialization-configmaps_test.yaml
@@ -4,6 +4,10 @@ templates:
 tests:
   - it: should apply correct changes to initialization-configmaps.yaml
     set:
+      glowroot:
+        enabled: true
+        version: 0.14.0
+        url: https://github.com/glowroot/glowroot/releases/download/v${GLOWROOT_VERSION}/glowroot-${GLOWROOT_VERSION}-dist.zip
       customConfigs:
         xwiki.properties:
           extension.repositories.privatemavenid.http.headers.headername: headervalue
@@ -21,3 +25,9 @@ tests:
       - matchRegex:
           path: data["entrypoint"]
           pattern: "core.defaultDocumentSyntax xwiki/2.1"
+      - matchRegex:
+          path: data["entrypoint"]
+          pattern: GLOWROOT_VERSION="0.14.0"
+      - matchRegex:
+          path: data["entrypoint"]
+          pattern: wget -O  \/tmp\/glowroot-\${GLOWROOT_VERSION}-dist\.zip https://github\.com/glowroot/glowroot/releases/download/v\${GLOWROOT_VERSION}/glowroot-\${GLOWROOT_VERSION}-dist\.zip

--- a/charts/xwiki/values.yaml
+++ b/charts/xwiki/values.yaml
@@ -315,6 +315,8 @@ properties:
 
 glowroot:
   enabled: false
+  version: 0.14.0
+  url: https://github.com/glowroot/glowroot/releases/download/v${GLOWROOT_VERSION}/glowroot-${GLOWROOT_VERSION}-dist.zip
   properties:
     data.dir: /usr/local/xwiki/data/glowroot/data
     log.dir: /usr/local/xwiki/data/glowroot/log


### PR DESCRIPTION
On this PR I added two options `version` and `url` to allow changing the glowroot JAR url

The version is used to change the `GLOWROOT_VERSION` variable and is afterwards used in the URL.