### PR TITLE
HELM-49: Solr extraEnvVars

### DIFF
--- a/charts/xwiki/templates/solr-statefulset.yaml
+++ b/charts/xwiki/templates/solr-statefulset.yaml
@@ -21,6 +21,11 @@ spec:
       initContainers:
       - name: download-cores
         image: curlimages/curl:8.2.1
+        env:
+        {{- range .Values.solr.extraEnvVars }}
+        - name: {{ .name  }}
+          value: {{ .value | quote }}
+        {{- end }}
         command: ['/bin/sh', '-c']
         volumeMounts:
           - name: xwiki-solr-data

--- a/charts/xwiki/values.yaml
+++ b/charts/xwiki/values.yaml
@@ -189,6 +189,9 @@ solr:
   enabled: false
   replicaCount: 1
   image: gridexx/xwiki:solr8
+  extraEnvVars: []
+    # - name: FOO
+    #   value: "bar"
   resources: {}
   service:
     portName: solr-node


### PR DESCRIPTION
Add the option to define environment variables inside init containers:

Useful use case:
- Define http_proxy/https_proxy environment variables to perform curl.