### PR TITLE
HELM-58 Improve security (ServiceAccount, securityContext) and harmonize indent

### DIFF
--- a/charts/xwiki/templates/ingress.yaml
+++ b/charts/xwiki/templates/ingress.yaml
@@ -42,20 +42,20 @@ spec:
       http:
         paths:
           {{- range .paths }}
-          - path: {{ .path }}
-            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
-            pathType: {{ .pathType }}
-            {{- end }}
-            backend:
-              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
-              service:
-                name: {{ $fullName }}
-                port:
-                  number: {{ $svcPort }}
-              {{- else }}
-              serviceName: {{ $fullName }}
-              servicePort: {{ $svcPort }}
+            - path: {{ .path }}
+              {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
+              pathType: {{ .pathType }}
               {{- end }}
+              backend:
+                {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+                service:
+                  name: {{ $fullName }}
+                  port:
+                    number: {{ $svcPort }}
+                {{- else }}
+                serviceName: {{ $fullName }}
+                servicePort: {{ $svcPort }}
+                {{- end }}
           {{- end }}
     {{- end }}
 {{- end -}}

--- a/charts/xwiki/templates/istio-certificate.yaml
+++ b/charts/xwiki/templates/istio-certificate.yaml
@@ -12,5 +12,5 @@ spec:
     {{- toYaml . | nindent 4 }}
   {{- end }}
   dnsNames:
-  - {{ .Values.istio.host | quote }}
+    - {{ .Values.istio.host | quote }}
 {{- end }}

--- a/charts/xwiki/templates/istio-gateway.yaml
+++ b/charts/xwiki/templates/istio-gateway.yaml
@@ -9,24 +9,24 @@ spec:
   selector:
     istio: {{ .Values.istio.gateway.selectorIstio | quote }} # use Istio default gateway implementation
   servers:
-  - hosts:
-    - {{ .Values.istio.host | quote }}
-    port:
-      number: 80
-      name: http
-      protocol: HTTP
-  {{- if .Values.istio.tls.enabled }}
-    tls:
-      httpsRedirect: {{ .Values.istio.tls.httpsRedirect }}
-  - port:
-      number: 443
-      name: https
-      protocol: HTTPS
-    tls:
-      credentialName: {{ (include "xwiki.istio.credentialName" .) }}
-      minProtocolVersion: {{ .Values.istio.tls.minProtocolVersion }}
-      mode: {{ .Values.istio.tls.mode }}
-    hosts:
-    - {{ .Values.istio.host | quote }}
-  {{- end }}
+    - hosts:
+        - {{ .Values.istio.host | quote }}
+      port:
+        number: 80
+        name: http
+        protocol: HTTP
+    {{- if .Values.istio.tls.enabled }}
+      tls:
+        httpsRedirect: {{ .Values.istio.tls.httpsRedirect }}
+    - port:
+        number: 443
+        name: https
+        protocol: HTTPS
+      tls:
+        credentialName: {{ (include "xwiki.istio.credentialName" .) }}
+        minProtocolVersion: {{ .Values.istio.tls.minProtocolVersion }}
+        mode: {{ .Values.istio.tls.mode }}
+      hosts:
+        - {{ .Values.istio.host | quote }}
+    {{- end }}
 {{- end }}

--- a/charts/xwiki/templates/istio.yaml
+++ b/charts/xwiki/templates/istio.yaml
@@ -5,23 +5,23 @@ metadata:
   name: {{ printf "%s-vs" (include "xwiki.fullname" .) }}
 spec:
   hosts:
-  - {{ .Values.istio.host | quote }}
+    - {{ .Values.istio.host | quote }}
   gateways:
-  - {{ template "xwiki.istio.gatewayName" . }}
+    - {{ template "xwiki.istio.gatewayName" . }}
   http:
-  - match:
-    - uri:
-        prefix: /
-    route:
-    - destination:
-        port:
-          number: {{ .Values.service.externalPort }}
-        host: {{ template "xwiki.fullname" . }}
-      headers:
-        request:
-          set:
-            # Required for some extensions (Realtime Editor/Websocket)
-            x-forwarded-host: {{ .Values.istio.host | quote }}
+    - match:
+        - uri:
+            prefix: /
+      route:
+        - destination:
+            port:
+              number: {{ .Values.service.externalPort }}
+            host: {{ template "xwiki.fullname" . }}
+          headers:
+            request:
+              set:
+                # Required for some extensions (Realtime Editor/Websocket)
+                x-forwarded-host: {{ .Values.istio.host | quote }}
 ---
 apiVersion: networking.istio.io/v1beta1
 kind: DestinationRule

--- a/charts/xwiki/templates/podmonitor.yaml
+++ b/charts/xwiki/templates/podmonitor.yaml
@@ -10,5 +10,5 @@ spec:
     matchLabels:
       {{- include "xwiki.selectorLabels" . | nindent 4 }}
   podMetricsEndpoints:
-    - port: monitoring
+      - port: monitoring
 {{- end }}

--- a/charts/xwiki/templates/service.yaml
+++ b/charts/xwiki/templates/service.yaml
@@ -13,15 +13,15 @@ spec:
     {{- end }}
   {{- end }}
   ports:
-  - port: {{ .Values.service.externalPort }}
-    targetPort: {{ .Values.service.internalPort }}
-    protocol: TCP
-    name: {{ .Values.service.name }}
+    - port: {{ .Values.service.externalPort }}
+      targetPort: {{ .Values.service.internalPort }}
+      protocol: TCP
+      name: {{ .Values.service.name }}
   {{- if .Values.prometheus.javaagent.enabled }}
-  - port: {{ .Values.prometheus.javaagent.port }}
-    targetPort: {{ .Values.prometheus.javaagent.port }}
-    protocol: TCP
-    name: monitoring
+    - port: {{ .Values.prometheus.javaagent.port }}
+      targetPort: {{ .Values.prometheus.javaagent.port }}
+      protocol: TCP
+      name: monitoring
   {{- end }}
   sessionAffinity: {{ .Values.service.sessionAffinity }}
   selector:

--- a/charts/xwiki/templates/solr-service.yaml
+++ b/charts/xwiki/templates/solr-service.yaml
@@ -8,10 +8,10 @@ metadata:
 spec:
   type: {{ .Values.solr.service.type }}
   ports:
-  - port: {{ .Values.solr.service.externalPort }}
-    targetPort: {{ .Values.solr.service.internalPort }}
-    protocol: TCP
-    name: {{ .Values.solr.service.name }}
+    - port: {{ .Values.solr.service.externalPort }}
+      targetPort: {{ .Values.solr.service.internalPort }}
+      protocol: TCP
+      name: {{ .Values.solr.service.name }}
   sessionAffinity: {{ .Values.solr.service.sessionAffinity }}
   selector:
     {{- include "solr.selectorLabels" . | nindent 4 }}

--- a/charts/xwiki/templates/solr-statefulset.yaml
+++ b/charts/xwiki/templates/solr-statefulset.yaml
@@ -19,44 +19,44 @@ spec:
         {{- include "solr.labels" . | nindent 8 }}
     spec:
       initContainers:
-      - name: download-cores
-        image: curlimages/curl:8.2.1
-        env:
-        {{- range .Values.solr.extraEnvVars }}
-        - name: {{ .name  }}
-          value: {{ .value | quote }}
-        {{- end }}
-        command: ['/bin/sh', '-c']
-        volumeMounts:
-          - name: xwiki-solr-data
-            mountPath: /tmp/cores
-        securityContext:
-          runAsGroup: 1001
-          runAsUser: 1001
-        args:
-        - |
-          SOLR_CORE_URL="https://maven.xwiki.org/releases/org/xwiki/platform/xwiki-platform-search-solr-server-core/15.5/xwiki-platform-search-solr-server-core-15.5.jar"
-          SOLR_MINIMAL_CORE_URL="https://maven.xwiki.org/releases/org/xwiki/platform/xwiki-platform-search-solr-server-core-minimal/15.5/xwiki-platform-search-solr-server-core-minimal-15.5.zip"
-          cd /tmp
-          curl $SOLR_CORE_URL -o ./xwiki-server-core.zip && \
-          curl $SOLR_MINIMAL_CORE_URL -o ./xwiki-minimal-core.zip
-          unzip -qqo ./xwiki-server-core.zip  -d ./cores/xwiki
-          unzip -qqo ./xwiki-minimal-core.zip -d ./cores/xwiki_events
-          unzip -qqo ./xwiki-minimal-core.zip -d ./cores/xwiki_extension_index
-          unzip -qqo ./xwiki-minimal-core.zip -d ./cores/xwiki_ratings
+        - name: download-cores
+          image: curlimages/curl:8.2.1
+          env:
+          {{- range .Values.solr.extraEnvVars }}
+            - name: {{ .name  }}
+              value: {{ .value | quote }}
+          {{- end }}
+          command: ['/bin/sh', '-c']
+          volumeMounts:
+            - name: xwiki-solr-data
+              mountPath: /tmp/cores
+          securityContext:
+            runAsGroup: 1001
+            runAsUser: 1001
+          args:
+            - |
+              SOLR_CORE_URL="https://maven.xwiki.org/releases/org/xwiki/platform/xwiki-platform-search-solr-server-core/15.5/xwiki-platform-search-solr-server-core-15.5.jar"
+              SOLR_MINIMAL_CORE_URL="https://maven.xwiki.org/releases/org/xwiki/platform/xwiki-platform-search-solr-server-core-minimal/15.5/xwiki-platform-search-solr-server-core-minimal-15.5.zip"
+              cd /tmp
+              curl $SOLR_CORE_URL -o ./xwiki-server-core.zip && \
+              curl $SOLR_MINIMAL_CORE_URL -o ./xwiki-minimal-core.zip
+              unzip -qqo ./xwiki-server-core.zip  -d ./cores/xwiki
+              unzip -qqo ./xwiki-minimal-core.zip -d ./cores/xwiki_events
+              unzip -qqo ./xwiki-minimal-core.zip -d ./cores/xwiki_extension_index
+              unzip -qqo ./xwiki-minimal-core.zip -d ./cores/xwiki_ratings
       containers:
-      - name: {{ printf "%s-solr" .Chart.Name }}
-        image: {{ .Values.solr.image }}
-        securityContext:
-          allowPrivilegeEscalation: false
-        imagePullPolicy: {{ .Values.image.pullPolicy }}
-        ports:
-        - containerPort: {{ .Values.solr.service.internalPort }}
-        resources:
-          {{ toYaml .Values.solr.resources | indent 12 }}
-        volumeMounts:
-        - name: xwiki-solr-data
-          mountPath: /var/solr/data
+        - name: {{ printf "%s-solr" .Chart.Name }}
+          image: {{ .Values.solr.image }}
+          securityContext:
+            allowPrivilegeEscalation: false
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - containerPort: {{ .Values.solr.service.internalPort }}
+          resources:
+            {{ toYaml .Values.solr.resources | indent 12 }}
+          volumeMounts:
+            - name: xwiki-solr-data
+              mountPath: /var/solr/data
       securityContext:
         fsGroup: 1001
     {{- with .Values.solr.nodeSelector }}
@@ -72,12 +72,12 @@ spec:
         {{- toYaml . | nindent 8 }}
     {{- end }}
       volumes:
-      - name: xwiki-solr-data
-        {{- if and .Values.solr.persistence.enabled .Values.solr.persistence.existingClaim }}
-        persistentVolumeClaim:
-          claimName: {{ tpl .Values.solr.persistence.existingClaim $ }}
+        - name: xwiki-solr-data
+          {{- if and .Values.solr.persistence.enabled .Values.solr.persistence.existingClaim }}
+          persistentVolumeClaim:
+            claimName: {{ tpl .Values.solr.persistence.existingClaim $ }}
   {{- else if not .Values.solr.persistence.enabled }}
-        emptyDir: {}
+          emptyDir: {}
   {{- else }}
   volumeClaimTemplates:
     - metadata:

--- a/charts/xwiki/templates/xwiki-sa.yaml
+++ b/charts/xwiki/templates/xwiki-sa.yaml
@@ -10,9 +10,9 @@ kind: Role
 metadata:
   name: {{ $fullName }}-pod-reader
 rules:
-- apiGroups: [""]
-  resources: ["pods"]
-  verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list", "watch"]
 ---
 kind: RoleBinding
 #kind: ClusterRoleBinding
@@ -20,9 +20,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ $fullName }}-api-access
 subjects:
-- kind: ServiceAccount
-  name: {{ $fullName }}-sa
-  namespace: {{ .Release.Namespace }}
+  - kind: ServiceAccount
+    name: {{ $fullName }}-sa
+    namespace: {{ .Release.Namespace }}
 roleRef:
   kind: Role
   #kind: ClusterRole

--- a/charts/xwiki/templates/xwiki-sa.yaml
+++ b/charts/xwiki/templates/xwiki-sa.yaml
@@ -1,16 +1,16 @@
-{{- if (.Values.cluster.enabled) }}
 {{- $fullName := include "xwiki.fullname" . -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ $fullName }}-sa
+{{- if (.Values.cluster.enabled) }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ $fullName }}-pod-reader
 rules:
-- apiGroups: [""] 
+- apiGroups: [""]
   resources: ["pods"]
   verbs: ["get", "list", "watch"]
 ---

--- a/charts/xwiki/templates/xwiki.yaml
+++ b/charts/xwiki/templates/xwiki.yaml
@@ -155,7 +155,7 @@ spec:
             successThreshold: {{ .Values.probes.readiness.successThreshold }}
         {{- end }}
           resources:
-  {{ toYaml .Values.resources | indent 12 }}
+            {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:
             - name: xwiki-data
               mountPath: /usr/local/xwiki/data

--- a/charts/xwiki/templates/xwiki.yaml
+++ b/charts/xwiki/templates/xwiki.yaml
@@ -27,9 +27,7 @@ spec:
       labels:
         {{- include "xwiki.labels" . | nindent 8 }}
     spec:
-      {{- if (.Values.cluster.enabled) }}
       serviceAccountName: {{ $fullName }}-sa
-      {{- end }}
       initContainers:
         {{- if and .Values.volumePermissions.enabled .Values.persistence.enabled }}
         - name: xwiki-data-permissions
@@ -40,8 +38,7 @@ spec:
             - -ec
             - |
               chown -R "{{ .Values.containerSecurityContext.runAsUser }}:{{ .Values.securityContext.fsGroup }}" /usr/local/xwiki/data
-          securityContext:
-            runAsUser: 0
+          securityContext: {{- omit .Values.volumePermissions.containerSecurityContext "enabled" | toYaml | nindent 12 }}
           volumeMounts:
             - name: xwiki-data
               mountPath: /usr/local/xwiki/data

--- a/charts/xwiki/templates/xwiki.yaml
+++ b/charts/xwiki/templates/xwiki.yaml
@@ -28,8 +28,8 @@ spec:
         {{- include "xwiki.labels" . | nindent 8 }}
     spec:
       serviceAccountName: {{ $fullName }}-sa
+      {{- if and .Values.volumePermissions.enabled .Values.persistence.enabled }}
       initContainers:
-        {{- if and .Values.volumePermissions.enabled .Values.persistence.enabled }}
         - name: xwiki-data-permissions
           image: {{ include "xwiki.imageName" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
@@ -42,7 +42,7 @@ spec:
           volumeMounts:
             - name: xwiki-data
               mountPath: /usr/local/xwiki/data
-        {{- end }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           image: {{ include "xwiki.imageName" . }}

--- a/charts/xwiki/templates/xwiki.yaml
+++ b/charts/xwiki/templates/xwiki.yaml
@@ -44,123 +44,123 @@ spec:
               mountPath: /usr/local/xwiki/data
         {{- end }}
       containers:
-      - name: {{ .Chart.Name }}
-        image: {{ include "xwiki.imageName" . }}
-        imagePullPolicy: {{ .Values.image.pullPolicy }}
-        command: ["/bin/bash", "/configmaps/entrypoint"]
-        {{- if .Values.containerSecurityContext.enabled }}
-        securityContext: {{- omit .Values.containerSecurityContext "enabled" | toYaml | nindent 12 }}
+        - name: {{ .Chart.Name }}
+          image: {{ include "xwiki.imageName" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command: ["/bin/bash", "/configmaps/entrypoint"]
+          {{- if .Values.containerSecurityContext.enabled }}
+          securityContext: {{- omit .Values.containerSecurityContext "enabled" | toYaml | nindent 12 }}
+          {{- end }}
+          ports:
+            - containerPort: {{ .Values.service.internalPort }}
+          {{- if (.Values.cluster.enabled) }}
+            - containerPort: {{ .Values.cluster.jgroups.port }}
+          {{- end }}
+          {{- if .Values.prometheus.javaagent.enabled }}
+            - containerPort: {{ .Values.prometheus.javaagent.port }}
+          {{- end }}
+          env:
+          {{- if .Values.javaOpts }}
+            - name: JAVA_OPTS
+              value: {{ .Values.javaOpts | join " " | quote }}
+          {{- end }}
+          {{- range .Values.extraEnvVars }}
+            - name: {{ .name  }}
+              value: {{ .value | quote }}
+          {{- end }}
+            - name: DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+          {{- if (and .Values.externalDB.customKeyRef .Values.externalDB.customKeyRef.enabled ) }}
+                  name: {{ .Values.externalDB.customKeyRef.name | quote }}
+                  key:  {{ .Values.externalDB.customKeyRef.key  | quote }}
+          {{- else if .Values.mysql.enabled }}
+                  name: "{{ .Release.Name }}-mysql"
+                  key: mysql-password
+          {{- else if .Values.postgresql.enabled }}
+                  name: "{{ .Release.Name }}-postgresql"
+                  key: password
+          {{- else }}
+                  name: {{ .Release.Name | quote }}
+                  key: DB_PASSWORD
+          {{- end }}
+          {{- if .Values.solr.enabled }}
+            - name: SOLR_BASEURL
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ $fullName }}
+                  key: SOLR_BASEURL
+          {{- end }}
+            - name: DB_HOST
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ $fullName }}
+                  key: DB_HOST
+            - name: DB_USER
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ $fullName }}
+                  key: DB_USER
+            - name: DB_DATABASE
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ $fullName }}
+                  key: DB_DATABASE
+        {{- if .Values.probes.startup.enabled }}
+          startupProbe:
+          {{- if .Values.probes.startup.httpGet.enabled }}
+            httpGet:
+              path: {{ .Values.probes.startup.httpGet.path }}
+              port: {{ .Values.service.internalPort }}
+          {{- else }}
+            tcpSocket:
+              port: {{ .Values.service.internalPort }}
+          {{- end }}
+            initialDelaySeconds: {{ .Values.probes.startup.initialDelaySeconds }}
+            timeoutSeconds: {{ .Values.probes.startup.timeoutSeconds }}
+            periodSeconds: {{ .Values.probes.startup.periodSeconds }}
+            failureThreshold: {{ .Values.probes.startup.failureThreshold }}
+            successThreshold: {{ .Values.probes.startup.successThreshold }}
         {{- end }}
-        ports:
-        - containerPort: {{ .Values.service.internalPort }}
-        {{- if (.Values.cluster.enabled) }}
-        - containerPort: {{ .Values.cluster.jgroups.port }}
+        {{- if .Values.probes.liveness.enabled }}
+          livenessProbe:
+          {{- if .Values.probes.liveness.httpGet.enabled }}
+            httpGet:
+              path: {{ .Values.probes.liveness.httpGet.path }}
+              port: {{ .Values.service.internalPort }}
+          {{- else }}
+            tcpSocket:
+              port: {{ .Values.service.internalPort }}
+          {{- end }}
+            initialDelaySeconds: {{ .Values.probes.liveness.initialDelaySeconds }}
+            timeoutSeconds: {{ .Values.probes.liveness.timeoutSeconds }}
+            periodSeconds: {{ .Values.probes.liveness.periodSeconds }}
+            failureThreshold: {{ .Values.probes.liveness.failureThreshold }}
+            successThreshold: {{ .Values.probes.liveness.successThreshold }}
         {{- end }}
-        {{- if .Values.prometheus.javaagent.enabled }}
-        - containerPort: {{ .Values.prometheus.javaagent.port }}
+        {{- if .Values.probes.readiness.enabled }}
+          readinessProbe:
+          {{- if .Values.probes.readiness.httpGet.enabled }}
+            httpGet:
+              path: {{ .Values.probes.liveness.httpGet.path }}
+              port: {{ .Values.service.internalPort }}
+          {{- else }}
+            tcpSocket:
+              port: {{ .Values.service.internalPort }}
+          {{- end }}
+            initialDelaySeconds: {{ .Values.probes.readiness.initialDelaySeconds }}
+            timeoutSeconds: {{ .Values.probes.readiness.timeoutSeconds }}
+            periodSeconds: {{ .Values.probes.readiness.periodSeconds }}
+            failureThreshold: {{ .Values.probes.readiness.failureThreshold }}
+            successThreshold: {{ .Values.probes.readiness.successThreshold }}
         {{- end }}
-        env:
-        {{- if .Values.javaOpts }}
-        - name: JAVA_OPTS
-          value: {{ .Values.javaOpts | join " " | quote }}
-        {{- end }}
-        {{- range .Values.extraEnvVars }}
-        - name: {{ .name  }}
-          value: {{ .value | quote }}
-        {{- end }}
-        - name: DB_PASSWORD
-          valueFrom:
-            secretKeyRef:
-        {{- if (and .Values.externalDB.customKeyRef .Values.externalDB.customKeyRef.enabled ) }}
-              name: {{ .Values.externalDB.customKeyRef.name | quote }}
-              key:  {{ .Values.externalDB.customKeyRef.key  | quote }}
-        {{- else if .Values.mysql.enabled }}
-              name: "{{ .Release.Name }}-mysql"
-              key: mysql-password
-        {{- else if .Values.postgresql.enabled }}
-              name: "{{ .Release.Name }}-postgresql"
-              key: password
-        {{- else }}
-              name: {{ .Release.Name | quote }}
-              key: DB_PASSWORD
-        {{- end }}
-        {{- if .Values.solr.enabled }}
-        - name: SOLR_BASEURL
-          valueFrom:
-            configMapKeyRef:
-              name: {{ $fullName }}
-              key: SOLR_BASEURL
-        {{- end }}
-        - name: DB_HOST
-          valueFrom:
-            configMapKeyRef:
-              name: {{ $fullName }}
-              key: DB_HOST
-        - name: DB_USER
-          valueFrom:
-            configMapKeyRef:
-              name: {{ $fullName }}
-              key: DB_USER
-        - name: DB_DATABASE
-          valueFrom:
-            configMapKeyRef:
-              name: {{ $fullName }}
-              key: DB_DATABASE
-      {{- if .Values.probes.startup.enabled }}
-        startupProbe:
-        {{- if .Values.probes.startup.httpGet.enabled }}
-          httpGet:
-            path: {{ .Values.probes.startup.httpGet.path }}
-            port: {{ .Values.service.internalPort }}
-        {{- else }}
-          tcpSocket:
-            port: {{ .Values.service.internalPort }}
-        {{- end }}
-          initialDelaySeconds: {{ .Values.probes.startup.initialDelaySeconds }}
-          timeoutSeconds: {{ .Values.probes.startup.timeoutSeconds }}
-          periodSeconds: {{ .Values.probes.startup.periodSeconds }}
-          failureThreshold: {{ .Values.probes.startup.failureThreshold }}
-          successThreshold: {{ .Values.probes.startup.successThreshold }}
-      {{- end }}
-      {{- if .Values.probes.liveness.enabled }}
-        livenessProbe:
-        {{- if .Values.probes.liveness.httpGet.enabled }}
-          httpGet:
-            path: {{ .Values.probes.liveness.httpGet.path }}
-            port: {{ .Values.service.internalPort }}
-        {{- else }}
-          tcpSocket:
-            port: {{ .Values.service.internalPort }}
-        {{- end }}
-          initialDelaySeconds: {{ .Values.probes.liveness.initialDelaySeconds }}
-          timeoutSeconds: {{ .Values.probes.liveness.timeoutSeconds }}
-          periodSeconds: {{ .Values.probes.liveness.periodSeconds }}
-          failureThreshold: {{ .Values.probes.liveness.failureThreshold }}
-          successThreshold: {{ .Values.probes.liveness.successThreshold }}
-      {{- end }}
-      {{- if .Values.probes.readiness.enabled }}
-        readinessProbe:
-        {{- if .Values.probes.readiness.httpGet.enabled }}
-          httpGet:
-            path: {{ .Values.probes.liveness.httpGet.path }}
-            port: {{ .Values.service.internalPort }}
-        {{- else }}
-          tcpSocket:
-            port: {{ .Values.service.internalPort }}
-        {{- end }}
-          initialDelaySeconds: {{ .Values.probes.readiness.initialDelaySeconds }}
-          timeoutSeconds: {{ .Values.probes.readiness.timeoutSeconds }}
-          periodSeconds: {{ .Values.probes.readiness.periodSeconds }}
-          failureThreshold: {{ .Values.probes.readiness.failureThreshold }}
-          successThreshold: {{ .Values.probes.readiness.successThreshold }}
-      {{- end }}
-        resources:
-{{ toYaml .Values.resources | indent 12 }}
-        volumeMounts:
-        - name: xwiki-data
-          mountPath: /usr/local/xwiki/data
-        - name: configmaps
-          mountPath: /configmaps
+          resources:
+  {{ toYaml .Values.resources | indent 12 }}
+          volumeMounts:
+            - name: xwiki-data
+              mountPath: /usr/local/xwiki/data
+            - name: configmaps
+              mountPath: /configmaps
     {{- if .Values.securityContext.enabled }}
       securityContext: {{- omit .Values.securityContext "enabled" | toYaml | nindent 8 }}
     {{- end }}
@@ -183,15 +183,15 @@ spec:
       {{- end }}
     {{- end }}
       volumes:
-      - name: configmaps
-        configMap:
-          name: {{ include "xwiki.initScripts" . }}
-      - name: xwiki-data
+        - name: configmaps
+          configMap:
+            name: {{ include "xwiki.initScripts" . }}
+        - name: xwiki-data
   {{- if and .Values.persistence.enabled .Values.persistence.existingClaim }}
-        persistentVolumeClaim:
-          claimName: {{ tpl .Values.persistence.existingClaim $ }}
+          persistentVolumeClaim:
+            claimName: {{ tpl .Values.persistence.existingClaim $ }}
   {{- else if not .Values.persistence.enabled }}
-        emptyDir: {}
+          emptyDir: {}
   {{- else if and .Values.workloadStateful (not .Values.cluster.enabled) }}
   volumeClaimTemplates:
     - metadata:
@@ -229,9 +229,9 @@ metadata:
     helm.sh/resource-policy: keep
 spec:
   accessModes:
-    {{- range .Values.persistence.accessModes }}
-      - {{ . | quote }}
-    {{- end }}
+  {{- range .Values.persistence.accessModes }}
+    - {{ . | quote }}
+  {{- end }}
   resources:
     requests:
       storage: {{ .Values.persistence.size | quote }}

--- a/charts/xwiki/values.yaml
+++ b/charts/xwiki/values.yaml
@@ -52,8 +52,15 @@ containerSecurityContext:
   enabled: false
   runAsUser: 100
   runAsNonRoot: true
+  seccompProfile:
+    type: "RuntimeDefault"
 
 volumePermissions:
+  containerSecurityContext:
+    enabled: true
+    runAsUser: 0
+    seccompProfile:
+      type: "RuntimeDefault"
   enabled: false
 
 ##

--- a/charts/xwiki/values.yaml
+++ b/charts/xwiki/values.yaml
@@ -188,7 +188,7 @@ externalDB:
   database: ''
   host: ''
 # If set to true default secret will not be created, use custom secret
-  custommKeyRef:
+  customKeyRef:
     enabled: false
     name: ''
     key: ''


### PR DESCRIPTION
Hey :wave: 

This PR does:
- ServiceAccount creation by default. This is recommend to comply with IT-Grundschutz and pass [compliance rule](https://gitlab.opencode.de/ig-bvc/ig-bvc-poc-2/ig-bvc-poc-ii-ap-4.1-ff-policy-entwicklung/rl-kyverno/-/blob/master/policies/disallow-default-serviceaccount.yaml)
- Harmonize indent of all list (indent 2)
- Remove empty `initContainers:` block in rendered template when `volumePermissions.enabled` is false.
- Fix typo `customKeyRef` which fixes rendering exception with default values.