### PR TITLE
HELM-61 add init containers

### DIFF
--- a/charts/xwiki/Chart.yaml
+++ b/charts/xwiki/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: XWiki is a free wiki software platform written in Java with a design emphasis on extensibility. XWiki is an enterprise wiki. It includes WYSIWYG editing, OpenDocument based document import/export, semantic annotations and tagging, and advanced permissions management.
 name: xwiki
-version: 1.3.1
+version: 1.4.0-Beta.0
 type: application
 keywords:
 - xwiki

--- a/charts/xwiki/templates/_helpers.tpl
+++ b/charts/xwiki/templates/_helpers.tpl
@@ -162,9 +162,9 @@ Command for the database init container
 {{- define "xwiki.initContainer.database.command" -}}
   {{- if .Values.initContainers.database.command }}
 {{ .Values.initContainers.database.command }}
-  {{- else if or .Values.mysql.enabled .Values.mariadb.enabled }}
-mysqladmin ping -h $DB_HOST -u $DB_USER -d $DB_DATABASE -p$DB_PASSWORD
-  {{- else if or .Values.postgresql.enabled }}
+  {{- else if or .Values.mysql.enabled .Values.mariadb.enabled (eq .Values.externalDB.type "mysql") (eq .Values.externalDB.type "mariadb") }}
+mysqladmin ping -h $DB_HOST -u $DB_USER -p$DB_PASSWORD
+  {{- else if or .Values.postgresql.enabled (eq .Values.externalDB.type "postgresql") }}
 PGPASSWORD=$DB_PASSWORD pg_isready -h $DB_HOST -U $DB_USER -d $DB_DATABASE
   {{- end }}
 {{- end }}

--- a/charts/xwiki/templates/_helpers.tpl
+++ b/charts/xwiki/templates/_helpers.tpl
@@ -102,3 +102,121 @@ Define which image to use
 {{- .Values.image.name -}}
 {{- end }}
 {{- end }}
+
+
+{{/*
+Database env vars
+*/}}
+{{- define "xwiki.database.env" }}
+- name: DB_PASSWORD
+  valueFrom:
+    secretKeyRef:
+    {{- if and .Values.externalDB.customKeyRef .Values.externalDB.customKeyRef.enabled }}
+      name: {{ .Values.externalDB.customKeyRef.name | quote }}
+      key:  {{ .Values.externalDB.customKeyRef.key  | quote }}
+    {{- else if .Values.mysql.enabled }}
+      name: "{{ .Release.Name }}-mysql"
+      key: mysql-password
+    {{- else if .Values.postgresql.enabled }}
+      name: "{{ .Release.Name }}-postgresql"
+      key: password
+    {{- else }}
+      name: {{ .Release.Name | quote }}
+      key: DB_PASSWORD
+    {{- end }}
+- name: DB_HOST
+  valueFrom:
+    configMapKeyRef:
+      name: {{ include "xwiki.fullname" . }}
+      key: DB_HOST
+- name: DB_USER
+  valueFrom:
+    configMapKeyRef:
+      name: {{ include "xwiki.fullname" . }}
+      key: DB_USER
+- name: DB_DATABASE
+  valueFrom:
+    configMapKeyRef:
+      name: {{ include "xwiki.fullname" . }}
+      key: DB_DATABASE
+{{- end }}
+
+{{/*
+Init Containers
+*/}}
+{{- define "xwiki.initContainers" -}}
+  {{- if and .Values.volumePermissions.enabled .Values.persistence.enabled }}
+- name: xwiki-data-permissions
+  image: {{ include "xwiki.imageName" . }}
+  imagePullPolicy: {{ .Values.image.pullPolicy }}
+  command:
+    - /bin/sh
+    - -ec
+    - chown -R "{{ .Values.containerSecurityContext.runAsUser }}:{{ .Values.securityContext.fsGroup }}" /usr/local/xwiki/data
+  securityContext: {{- omit .Values.volumePermissions.containerSecurityContext "enabled" | toYaml | nindent 12 }}
+  volumeMounts:
+    - name: xwiki-data
+      mountPath: /usr/local/xwiki/data
+  {{- end }}
+  {{- if .Values.initContainers.database.enabled }}
+- name: wait-for-db
+  {{- if .Values.initContainers.database.containerSecurityContext.enabled }}
+  securityContext:
+    {{- omit .Values.initContainers.database.containerSecurityContext "enabled" | toYaml | nindent 6 }}
+  {{- end }}
+  env:
+    {{- include "xwiki.database.env" . | nindent 6 }}
+    {{- if .Values.mysql.enabled }}
+  image: "{{ .Values.mysql.image.repository }}:{{ .Values.mysql.image.tag }}"
+  command: ["/bin/sh", "-ec", "check_db='mysqladmin ping -h $DB_HOST -u $DB_USER -d $DB_DATABASE -p$DB_PASSWORD'"]
+    {{- else if .Values.postgresql.enabled }}
+  image: "{{ .Values.postgresql.image.repository }}:{{ .Values.postgresql.image.tag }}"
+  command: ["/bin/sh", "-ec", "check_db='PGPASSWORD=$DB_PASSWORD pg_isready -h $DB_HOST -U $DB_USER -d $DB_DATABASE'"]
+    {{- else if .Values.mariadb.enabled }}
+  image: "{{ .Values.mariadb.image.repository }}:{{ .Values.mariadb.image.tag }}"
+  command: ["/bin/sh", "-ec", "check_db='mysqladmin ping -h $DB_HOST -u $DB_USER -d $DB_DATABASE -p$DB_PASSWORD'"]
+    {{- else }}
+      {{- fail ".Values.initContainers.database.enabled is not supported with external databases" }}
+    {{- end }}
+  args:
+    - |
+      for i in $(seq 1 30); do
+        if eval $check_db; then
+          echo "Database is ready!"
+          exit 0
+        fi
+        echo "Waiting for database..."
+        sleep 1
+      done
+      echo "Database is not ready!"
+      exit 1
+  {{- end }}
+  {{- if .Values.initContainers.solr.enabled }}
+- name: wait-for-solr
+  image: "alpine/curl:8.9.0"
+  command:
+    - /bin/sh
+    - -ec
+    - |
+      for i in $(seq 1 30); do
+        if curl --silent --connect-timeout "15000" $SOLR_BASEURL/admin/info/system | grep '\"status\":0'
+          echo "Solr is ready!"
+          exit 0
+        fi
+        echo "Waiting for Solr..."
+        sleep 1
+      done
+      echo "Solr is not ready!"
+      exit 1
+  {{- if .Values.initContainers.solr.containerSecurityContext.enabled }}
+  securityContext:
+    {{- omit .Values.initContainers.solr.containerSecurityContext "enabled" | toYaml | nindent 6 }}
+  {{- end }}
+  env:
+    - name: SOLR_BASEURL
+      valueFrom:
+        configMapKeyRef:
+          name: {{ include "xwiki.fullname" . }}
+          key: SOLR_BASEURL
+  {{- end }}
+{{- end }}

--- a/charts/xwiki/templates/xwiki.yaml
+++ b/charts/xwiki/templates/xwiki.yaml
@@ -28,20 +28,9 @@ spec:
         {{- include "xwiki.labels" . | nindent 8 }}
     spec:
       serviceAccountName: {{ $fullName }}-sa
-      {{- if and .Values.volumePermissions.enabled .Values.persistence.enabled }}
+      {{- if or .Values.initContainers.database.enabled .Values.initContainers.solr.enabled (and .Values.volumePermissions.enabled .Values.persistence.enabled) }}
       initContainers:
-        - name: xwiki-data-permissions
-          image: {{ include "xwiki.imageName" . }}
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
-          command:
-            - /bin/sh
-            - -ec
-            - |
-              chown -R "{{ .Values.containerSecurityContext.runAsUser }}:{{ .Values.securityContext.fsGroup }}" /usr/local/xwiki/data
-          securityContext: {{- omit .Values.volumePermissions.containerSecurityContext "enabled" | toYaml | nindent 12 }}
-          volumeMounts:
-            - name: xwiki-data
-              mountPath: /usr/local/xwiki/data
+        {{- include "xwiki.initContainers" . | nindent 8 }}
       {{- end }}
       containers:
         - name: {{ .Chart.Name }}
@@ -68,22 +57,7 @@ spec:
             - name: {{ .name  }}
               value: {{ .value | quote }}
           {{- end }}
-            - name: DB_PASSWORD
-              valueFrom:
-                secretKeyRef:
-          {{- if (and .Values.externalDB.customKeyRef .Values.externalDB.customKeyRef.enabled ) }}
-                  name: {{ .Values.externalDB.customKeyRef.name | quote }}
-                  key:  {{ .Values.externalDB.customKeyRef.key  | quote }}
-          {{- else if .Values.mysql.enabled }}
-                  name: "{{ .Release.Name }}-mysql"
-                  key: mysql-password
-          {{- else if .Values.postgresql.enabled }}
-                  name: "{{ .Release.Name }}-postgresql"
-                  key: password
-          {{- else }}
-                  name: {{ .Release.Name | quote }}
-                  key: DB_PASSWORD
-          {{- end }}
+          {{ include "xwiki.database.env" . | indent 12 }}
           {{- if .Values.solr.enabled }}
             - name: SOLR_BASEURL
               valueFrom:
@@ -91,21 +65,6 @@ spec:
                   name: {{ $fullName }}
                   key: SOLR_BASEURL
           {{- end }}
-            - name: DB_HOST
-              valueFrom:
-                configMapKeyRef:
-                  name: {{ $fullName }}
-                  key: DB_HOST
-            - name: DB_USER
-              valueFrom:
-                configMapKeyRef:
-                  name: {{ $fullName }}
-                  key: DB_USER
-            - name: DB_DATABASE
-              valueFrom:
-                configMapKeyRef:
-                  name: {{ $fullName }}
-                  key: DB_DATABASE
         {{- if .Values.probes.startup.enabled }}
           startupProbe:
           {{- if .Values.probes.startup.httpGet.enabled }}

--- a/charts/xwiki/tests/__snapshot__/xwiki_test.yaml.snap
+++ b/charts/xwiki/tests/__snapshot__/xwiki_test.yaml.snap
@@ -37,7 +37,7 @@ should create a mariadb init container:
               key: DB_DATABASE
               name: RELEASE-NAME-xwiki
         - name: CHECK_DB
-          value: mysqladmin ping -h $DB_HOST -u $DB_USER -d $DB_DATABASE -p$DB_PASSWORD
+          value: mysqladmin ping -h $DB_HOST -u $DB_USER -p$DB_PASSWORD
       image: mariadb:latest
       name: wait-for-db
 should create a mysql init container:
@@ -79,7 +79,7 @@ should create a mysql init container:
               key: DB_DATABASE
               name: RELEASE-NAME-xwiki
         - name: CHECK_DB
-          value: mysqladmin ping -h $DB_HOST -u $DB_USER -d $DB_DATABASE -p$DB_PASSWORD
+          value: mysqladmin ping -h $DB_HOST -u $DB_USER -p$DB_PASSWORD
       image: mysql:latest
       name: wait-for-db
 should create a postgres init container:
@@ -148,13 +148,55 @@ should create a solr init container:
               name: RELEASE-NAME-xwiki
       image: alpine/curl:8.9.0
       name: wait-for-solr
+should create an external db init container for mysql:
+  1: |
+    - args:
+        - |
+          for i in $(seq 1 30); do
+            if eval $CHECK_DB; then
+              echo "Database is ready!"
+              exit 0
+            fi
+            echo "Waiting for database..."
+            sleep 1
+          done
+          echo "Database is not ready!"
+          exit 1
+      command:
+        - /bin/sh
+        - -ec
+      env:
+        - name: DB_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              key: custom-key
+              name: custom-secret
+        - name: DB_HOST
+          valueFrom:
+            configMapKeyRef:
+              key: DB_HOST
+              name: RELEASE-NAME-xwiki
+        - name: DB_USER
+          valueFrom:
+            configMapKeyRef:
+              key: DB_USER
+              name: RELEASE-NAME-xwiki
+        - name: DB_DATABASE
+          valueFrom:
+            configMapKeyRef:
+              key: DB_DATABASE
+              name: RELEASE-NAME-xwiki
+        - name: CHECK_DB
+          value: mysqladmin ping -h $DB_HOST -u $DB_USER -p$DB_PASSWORD
+      image: mysql:latest
+      name: wait-for-db
 should use custom DB password secret:
   1: |
     - name: DB_PASSWORD
       valueFrom:
         secretKeyRef:
           key: custom-key
-          name: custom-secreat
+          name: custom-secret
     - name: DB_HOST
       valueFrom:
         configMapKeyRef:

--- a/charts/xwiki/tests/__snapshot__/xwiki_test.yaml.snap
+++ b/charts/xwiki/tests/__snapshot__/xwiki_test.yaml.snap
@@ -1,3 +1,153 @@
+should create a mariadb init container:
+  1: |
+    - args:
+        - |
+          for i in $(seq 1 30); do
+            if eval $CHECK_DB; then
+              echo "Database is ready!"
+              exit 0
+            fi
+            echo "Waiting for database..."
+            sleep 1
+          done
+          echo "Database is not ready!"
+          exit 1
+      command:
+        - /bin/sh
+        - -ec
+      env:
+        - name: DB_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              key: DB_PASSWORD
+              name: RELEASE-NAME
+        - name: DB_HOST
+          valueFrom:
+            configMapKeyRef:
+              key: DB_HOST
+              name: RELEASE-NAME-xwiki
+        - name: DB_USER
+          valueFrom:
+            configMapKeyRef:
+              key: DB_USER
+              name: RELEASE-NAME-xwiki
+        - name: DB_DATABASE
+          valueFrom:
+            configMapKeyRef:
+              key: DB_DATABASE
+              name: RELEASE-NAME-xwiki
+        - name: CHECK_DB
+          value: mysqladmin ping -h $DB_HOST -u $DB_USER -d $DB_DATABASE -p$DB_PASSWORD
+      image: mariadb:latest
+      name: wait-for-db
+should create a mysql init container:
+  1: |
+    - args:
+        - |
+          for i in $(seq 1 30); do
+            if eval $CHECK_DB; then
+              echo "Database is ready!"
+              exit 0
+            fi
+            echo "Waiting for database..."
+            sleep 1
+          done
+          echo "Database is not ready!"
+          exit 1
+      command:
+        - /bin/sh
+        - -ec
+      env:
+        - name: DB_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              key: mysql-password
+              name: RELEASE-NAME-mysql
+        - name: DB_HOST
+          valueFrom:
+            configMapKeyRef:
+              key: DB_HOST
+              name: RELEASE-NAME-xwiki
+        - name: DB_USER
+          valueFrom:
+            configMapKeyRef:
+              key: DB_USER
+              name: RELEASE-NAME-xwiki
+        - name: DB_DATABASE
+          valueFrom:
+            configMapKeyRef:
+              key: DB_DATABASE
+              name: RELEASE-NAME-xwiki
+        - name: CHECK_DB
+          value: mysqladmin ping -h $DB_HOST -u $DB_USER -d $DB_DATABASE -p$DB_PASSWORD
+      image: mysql:latest
+      name: wait-for-db
+should create a postgres init container:
+  1: |
+    - args:
+        - |
+          for i in $(seq 1 30); do
+            if eval $CHECK_DB; then
+              echo "Database is ready!"
+              exit 0
+            fi
+            echo "Waiting for database..."
+            sleep 1
+          done
+          echo "Database is not ready!"
+          exit 1
+      command:
+        - /bin/sh
+        - -ec
+      env:
+        - name: DB_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              key: password
+              name: RELEASE-NAME-postgresql
+        - name: DB_HOST
+          valueFrom:
+            configMapKeyRef:
+              key: DB_HOST
+              name: RELEASE-NAME-xwiki
+        - name: DB_USER
+          valueFrom:
+            configMapKeyRef:
+              key: DB_USER
+              name: RELEASE-NAME-xwiki
+        - name: DB_DATABASE
+          valueFrom:
+            configMapKeyRef:
+              key: DB_DATABASE
+              name: RELEASE-NAME-xwiki
+        - name: CHECK_DB
+          value: PGPASSWORD=$DB_PASSWORD pg_isready -h $DB_HOST -U $DB_USER -d $DB_DATABASE
+      image: postgres:latest
+      name: wait-for-db
+should create a solr init container:
+  1: |
+    - command:
+        - /bin/sh
+        - -ec
+        - |
+          for i in $(seq 1 30); do
+            if curl --silent --connect-timeout "15000" $SOLR_BASEURL/admin/info/system | grep '\"status\":0'
+              echo "Solr is ready!"
+              exit 0
+            fi
+            echo "Waiting for Solr..."
+            sleep 1
+          done
+          echo "Solr is not ready!"
+          exit 1
+      env:
+        - name: SOLR_BASEURL
+          valueFrom:
+            configMapKeyRef:
+              key: SOLR_BASEURL
+              name: RELEASE-NAME-xwiki
+      image: alpine/curl:8.9.0
+      name: wait-for-solr
 should use custom DB password secret:
   1: |
     - name: DB_PASSWORD

--- a/charts/xwiki/tests/xwiki_test.yaml
+++ b/charts/xwiki/tests/xwiki_test.yaml
@@ -116,3 +116,47 @@ tests:
       - matchSnapshot:
           path: spec.template.spec.containers[0].env
         template: xwiki.yaml
+  - it: should create a postgres init container
+    set:
+      mysql.enabled: false
+      postgresql.enabled: true
+      mariadb.enabled: false
+      initContainers.database.enabled: true
+      postgresql.image.repository: "postgres"
+      postgresql.image.tag: "latest"
+    asserts:
+      - matchSnapshot:
+          path: spec.template.spec.initContainers
+        template: xwiki.yaml
+  - it: should create a mariadb init container
+    set:
+      mysql.enabled: false
+      postgresql.enabled: false
+      mariadb.enabled: true
+      initContainers.database.enabled: true
+      mariadb.image.repository: "mariadb"
+      mariadb.image.tag: "latest"
+    asserts:
+      - matchSnapshot:
+          path: spec.template.spec.initContainers
+        template: xwiki.yaml
+  - it: should create a mysql init container
+    set:
+      mysql.enabled: true
+      postgresql.enabled: false
+      mariadb.enabled: false
+      initContainers.database.enabled: true
+      mysql.image.repository: "mysql"
+      mysql.image.tag: "latest"
+    asserts:
+      - matchSnapshot:
+          path: spec.template.spec.initContainers
+        template: xwiki.yaml
+  - it: should create a solr init container
+    set:
+      solr.enabled: true
+      initContainers.solr.enabled: true
+    asserts:
+      - matchSnapshot:
+          path: spec.template.spec.initContainers
+        template: xwiki.yaml

--- a/charts/xwiki/tests/xwiki_test.yaml
+++ b/charts/xwiki/tests/xwiki_test.yaml
@@ -110,7 +110,7 @@ tests:
   - it: should use custom DB password secret
     set:
       externalDB.customKeyRef.enabled: true
-      externalDB.customKeyRef.name: "custom-secreat"
+      externalDB.customKeyRef.name: "custom-secret"
       externalDB.customKeyRef.key: "custom-key"
     asserts:
       - matchSnapshot:
@@ -156,6 +156,18 @@ tests:
     set:
       solr.enabled: true
       initContainers.solr.enabled: true
+    asserts:
+      - matchSnapshot:
+          path: spec.template.spec.initContainers
+        template: xwiki.yaml
+  - it: should create an external db init container for mysql
+    set:
+      externalDB.customKeyRef.enabled: true
+      externalDB.customKeyRef.name: "custom-secret"
+      externalDB.customKeyRef.key: "custom-key"
+      externalDB.type: "mysql"
+      initContainers.database.enabled: true
+      initContainers.database.image: "mysql:latest"
     asserts:
       - matchSnapshot:
           path: spec.template.spec.initContainers

--- a/charts/xwiki/values.yaml
+++ b/charts/xwiki/values.yaml
@@ -193,7 +193,9 @@ externalDB:
   user: ''
   database: ''
   host: ''
-# If set to true default secret will not be created, use custom secret
+  # To set if database init containers are enabled, supported values are mysql, postgresql, mariadb
+  type: ''
+  # If set to true default secret will not be created, use custom secret
   customKeyRef:
     enabled: false
     name: ''
@@ -350,6 +352,10 @@ properties:
 initContainers:
   database:
     enabled: false
+    # Custom command to be executed in the init container
+    # command: ''
+    # To set when using externalDB
+    # image: "mysql:latest"
     containerSecurityContext:
       enabled: false
       runAsUser: 0

--- a/charts/xwiki/values.yaml
+++ b/charts/xwiki/values.yaml
@@ -351,14 +351,14 @@ initContainers:
   database:
     enabled: false
     containerSecurityContext:
-      enabled: true
+      enabled: false
       runAsUser: 0
       seccompProfile:
         type: "RuntimeDefault"
   solr:
     enabled: false
     containerSecurityContext:
-      enabled: true
+      enabled: false
       runAsUser: 0
       seccompProfile:
         type: "RuntimeDefault"

--- a/charts/xwiki/values.yaml
+++ b/charts/xwiki/values.yaml
@@ -346,6 +346,23 @@ customConfigs:
 properties:
   # "key": "value"
 
+# Init containers for the xwiki deployment/statefullSet
+initContainers:
+  database:
+    enabled: false
+    containerSecurityContext:
+      enabled: true
+      runAsUser: 0
+      seccompProfile:
+        type: "RuntimeDefault"
+  solr:
+    enabled: false
+    containerSecurityContext:
+      enabled: true
+      runAsUser: 0
+      seccompProfile:
+        type: "RuntimeDefault"
+
 glowroot:
   enabled: false
   version: 0.14.0


### PR DESCRIPTION
This PR adds support for initContainers to check database and solr. They can be enabled with `initContainers.database.enabled` and `initContainers.solr.enabled`. I'm not sure if this is a good idea, but I wanted to make sure not to break a future version, we can change that if you think it's not right.

- [x] Init container for solr
- [x] Init container for database (mariadb, postgres, mysql)
- [x] Init container for external database (maybe add support for custom init containers?)
- [x] Tests
