### PR TITLE
HELM-60 fix readiness probe typo

### DIFF
--- a/charts/xwiki/Chart.yaml
+++ b/charts/xwiki/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: XWiki is a free wiki software platform written in Java with a design emphasis on extensibility. XWiki is an enterprise wiki. It includes WYSIWYG editing, OpenDocument based document import/export, semantic annotations and tagging, and advanced permissions management.
 name: xwiki
-version: 1.4.0-Beta.1
+version: 1.4.0-Beta.2
 type: application
 keywords:
 - xwiki

--- a/charts/xwiki/templates/xwiki.yaml
+++ b/charts/xwiki/templates/xwiki.yaml
@@ -101,7 +101,7 @@ spec:
           readinessProbe:
           {{- if .Values.probes.readiness.httpGet.enabled }}
             httpGet:
-              path: {{ .Values.probes.liveness.httpGet.path }}
+              path: {{ .Values.probes.readiness.httpGet.path }}
               port: {{ .Values.service.internalPort }}
           {{- else }}
             tcpSocket:


### PR DESCRIPTION
[This issue](https://jira.xwiki.org/projects/HELM/issues/HELM-60?filter=allopenissues) was already addressed, but a typo in the template made it not work.
