### PR TITLE
HELM-69 Fix wrong indent of default volume body

### DIFF
--- a/charts/xwiki/templates/xwiki.yaml
+++ b/charts/xwiki/templates/xwiki.yaml
@@ -183,8 +183,8 @@ spec:
         {{- end }}
         {{- include "common.storage.class" (dict "persistence" .Values.persistence "global" .Values.global) | nindent 8 }}
   {{- else }}
-  persistentVolumeClaim:
-    claimName: xwiki
+          persistentVolumeClaim:
+            claimName: xwiki
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim


### PR DESCRIPTION
# Problem 

When installing the xwiki helmchart on our cluster I had the following output.

```bash
user@MBP:~/xwiki_helm$ helm upgrade -f custom_values.yaml --create-namespace -n helm-xwiki xwiki xwiki-helm/xwiki
W0904 15:25:39.568568   31203 warnings.go:70] unknown field "spec.persistentVolumeClaim"
Release "xwiki" has been upgraded. Happy Helming!
NAME: xwiki
LAST DEPLOYED: Wed Sep  4 15:25:37 2024
NAMESPACE: helm-xwiki
STATUS: deployed
REVISION: 2
TEST SUITE: None
NOTES:
```

Note the second line with the error: `W0904 15:25:39.568568   31203 warnings.go:70] unknown field "spec.persistentVolumeClaim"` 

Also I noticed that the pvc for the xwiki volume was marked as pending forever, because it stayed unbound. 

I looked a bit deeper into the helmchart and found out, that the issue was a wrongly indented body of the volume definition.

# Solution 

Indented the body of the volume definition up to the right indention level. 

## Miscellaneous

The indent level of `- name: xwiki-data` right below `spec.template.volumes` is 9 and the body is at 11. Theirefore the indent of `persistentVolumeClaim:` has to be at 11 too.
