### PR TITLE
HELM-73 Remove ingress.class annotation

### DIFF
--- a/charts/xwiki/values.yaml
+++ b/charts/xwiki/values.yaml
@@ -240,7 +240,6 @@ ingress:
   enabled: false
   className: ""
   annotations:
-    kubernetes.io/ingress.class: nginx
     nginx.ingress.kubernetes.io/affinity: cookie
     nginx.ingress.kubernetes.io/session-cookie-name: XNGINX
     nginx.ingress.kubernetes.io/session-cookie-expires: "1800"


### PR DESCRIPTION
When defining a custom ingress class via .Values.ingress.className it conflicts with the default annotation.

Reported via https://gitlab.opencode.de/bmi/opendesk/deployment/opendesk/-/issues/144