### PR TITLE
HELM-91: Fix fallback to plain value when secret is null/empty

### DIFF
--- a/charts/xwiki/templates/_helpers.tpl
+++ b/charts/xwiki/templates/_helpers.tpl
@@ -204,7 +204,7 @@ Init Containers for secrets
           {{- if hasKey $value "secret" }}
           {{- if and $value.secret.name $value.secret.key }}
           name: {{ $value.secret.name | default $fullName | quote }}
-          key: {{ $value.secret.key | default $keySanitised |quote }}
+          key: {{ $value.secret.key | default $keySanitised | quote }}
           {{- else }}
           name: {{ $fullName | quote }}
           key: {{ $keySanitised | quote }}
@@ -223,7 +223,7 @@ Init Containers for secrets
           {{- if hasKey $value "secret" }}
           {{- if and $value.secret.name $value.secret.key }}
           name: {{ $value.secret.name | default $fullName | quote }}
-          key: {{ $value.secret.key | default $keySanitised |quote }}
+          key: {{ $value.secret.key | default $keySanitised | quote }}
           {{- else }}
           name: {{ $fullName | quote }}
           key: {{ $keySanitised | quote }}

--- a/charts/xwiki/templates/secrets.yaml
+++ b/charts/xwiki/templates/secrets.yaml
@@ -25,12 +25,16 @@ data:
   {{- range $key, $value := $values }}
     {{- if not (index $value "secret") }}
       {{- regexReplaceAll "\\W+" $key "_" | nindent 2 }}: {{ $value.value | b64enc | quote }}
+    {{- else if and (not $value.name) (not $value.key) }}
+      {{- regexReplaceAll "\\W+" $key "_" | nindent 2 }}: {{ $value.value | b64enc | quote }}
     {{- end }}
   {{- end }}
 {{- end }}
 
 {{- range $key, $value := .Values.javaOptsSecrets }}
   {{- if not (index $value "secret") }}
+    {{- regexReplaceAll "\\W+" $key "_" | nindent 2 }}: {{ $value.value | b64enc | quote }}
+  {{- else if and (not $value.name) (not $value.key) }}
     {{- regexReplaceAll "\\W+" $key "_" | nindent 2 }}: {{ $value.value | b64enc | quote }}
   {{- end }}
 {{- end }}


### PR DESCRIPTION
When the values (`name`, `key`) for an external secret are empty or null but `secret` is present the fallback plain `value` was ignored.