### PR TITLE
HELM-92: Fix, add support for external secrets for properties

### DIFF
--- a/charts/xwiki/Chart.yaml
+++ b/charts/xwiki/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: XWiki is a free wiki software platform written in Java with a design emphasis on extensibility. XWiki is an enterprise wiki. It includes WYSIWYG editing, OpenDocument based document import/export, semantic annotations and tagging, and advanced permissions management.
 name: xwiki
-version: 1.5.2
+version: 1.5.3
 type: application
 keywords:
 - xwiki

--- a/charts/xwiki/templates/initialization-secrets.yaml
+++ b/charts/xwiki/templates/initialization-secrets.yaml
@@ -162,26 +162,79 @@ stringData:
       xwiki_replace_or_add /usr/local/xwiki/data/xwiki.properties "observation.remote.channels" "kubeping"
     {{- end }}
 
+    # Append property options and their values delimited by "=" read from a file to
+    # the list of properties.
+    # If a key(option) already exists from the plain value, it is overwritten by the value
+    # from the secret file.
+    injectPropertiesFromSecret () {
+      properties="${1}"
+
+      while IFS="" read -r property || [ -n "${property}" ]; do
+        # skip lines without a "="
+        if [[ ${property} != *"="* ]]; then
+          continue
+        fi
+        # substitute string before =
+        key="${property%%=*}"
+        # substitute string after =
+        value="${property#*=}"
+        properties["${key}"]="${value}"
+      done < {{ printf "/secretproperties/%s" .Values.propertiesSecret.key }}
+    }
+
+    # Append properties prefixed with "-D" from a secret that provides properties in a file.
+    # If no parameter is given append to the environment variable "JAVA_OPTS"
+    # otherwise append to the file given as a parameter.
+    publishProperties () {
+      properties="${1}"
+      outFile="${2}"
+
+      for key in "${!properties[@]}"; do
+        # skip element that either miss key OR value
+        if [[ -z "${key}" || -z "${properties[${key}]}" ]]; then
+          continue
+        fi
+        # If no output file is given we fill the environment variable
+        if [[ -z ${outFile} ]]; then
+          printf -v property -- '-D%s=%s' "${key}" "${properties[${key}]}"
+          export JAVA_OPTS=${JAVA_OPTS:+${JAVA_OPTS} }${property}
+        else
+          # If the output file doesn't exist, create it
+          if [[ ! -f ${outFile} ]]; then
+            echo "" > "${outFile}"
+          fi
+          printf -- '-D%s=%s\n' "${key}" "${properties[${key}]}" >> "${outFile}"
+        fi
+      done
+    }
+
+    # Utilise an associative array to set properties.
+    declare -A properties
+
+    {{- range $prop, $value := .Values.properties }}
+    properties[{{ $prop | quote }}]={{ $value | quote }}
+    {{- end }}
+
+    {{- if and .Values.propertiesSecret.name .Values.propertiesSecret.key }}
+    injectPropertiesFromSecret properties
+    {{- end }}
+
     if [ -d "/var/lib/jetty" ]; then
-      echo "" > start.d/xwiki.ini 
-      {{- range $prop, $value := .Values.properties }}
-        echo '-D{{ $prop }}={{ $value }}' >> start.d/xwiki.ini 
-      {{- end }}
+      echo "" > start.d/xwiki.ini
+      publishProperties properties start.d/xwiki.ini
       export JAVA_OPTIONS="${JAVA_OPTS}"
     else 
       if (/usr/local/tomcat/bin/version.sh | grep -q 'Tomcat/8'); then
         echo "Old Tomcat don't support java_opts file... Using normal props."
-        {{- range $prop, $value := .Values.properties }}
-          export JAVA_OPTS="${JAVA_OPTS} -D{{ $prop }}={{ $value }}"
-        {{- end }}
+        publishProperties properties
       else 
         ## Clear contents of /tmp/java_opts.txt so that we don't add extra arguments at each pod restart.
         echo "" > /tmp/java_opts.txt
-        {{- range $prop, $value := .Values.properties }}
-          echo '-D{{ $prop }}="{{ $value }}"' >> /tmp/java_opts.txt
-        {{- end }}
+        publishProperties properties /tmp/java_opts.txt
         export JAVA_OPTS="${JAVA_OPTS} @/tmp/java_opts.txt"
       fi
-    fi 
+    fi
+
+    unset properties
 
     exec /usr/local/bin/docker-entrypoint.sh xwiki

--- a/charts/xwiki/templates/xwiki.yaml
+++ b/charts/xwiki/templates/xwiki.yaml
@@ -126,6 +126,11 @@ spec:
               mountPath: /usr/local/xwiki/data
             - name: configmaps
               mountPath: /configmaps
+            {{- if and .Values.propertiesSecret.name .Values.propertiesSecret.key }}
+            - name: secretproperties
+              mountPath: /secretproperties
+              readOnly: true
+            {{- end }}
             - name: entrypoint
               mountPath: /entrypoint
               readOnly: true
@@ -167,6 +172,11 @@ spec:
         - name: secrets
           secret:
             secretName: {{ include "xwiki.initScripts" . }}
+        {{- if and .Values.propertiesSecret.name .Values.propertiesSecret.key }}
+        - name: secretproperties
+          secret:
+            secretName: {{ .Values.propertiesSecret.name }}
+        {{- end }}
         - name: entrypoint
           emptyDir:
             sizeLimit: 1Mi

--- a/charts/xwiki/values.yaml
+++ b/charts/xwiki/values.yaml
@@ -432,6 +432,17 @@ customConfigsSecrets:
 properties:
   # "key": "value"
 
+# Name of a secret that contains a file listing properties and their value separated by '=' line by line.
+# Those values will be prefixed by '-D' and depending on the used software/version appended to the environment
+# variable 'JAVA_OPTS' or a file that holds properties and get loaded later on.
+# The following example shows a single line how it is expected to be formatted:
+# property:xwiki:Mail.MailConfig^Mail.SendMailConfigClass.password="<password>"
+propertiesSecret:
+  # -- Name of the Kubernetes secret that contains the properties file
+  name: ""
+  # -- Key inside the Kubernetes secret that contains the properties file
+  key: ""
+
 # Init containers for the xwiki deployment/statefullSet
 initContainers:
   database:


### PR DESCRIPTION
This PR introduces the possibility to provide properties with confidential data in a secret that contains a file listing properties and their value. 