### PR TITLE
fix(service): render multiple service.annotations correctly

### DIFF
--- a/charts/xwiki/templates/service.yaml
+++ b/charts/xwiki/templates/service.yaml
@@ -6,10 +6,10 @@ metadata:
     {{- include "xwiki.labels" . | nindent 4 }}
   annotations:
     {{- if .Values.service.annotations }}
-    {{ .Values.service.annotations | toYaml | indent 4 }}
+    {{- toYaml .Values.service.annotations | nindent 4 }}
     {{- end }}
     {{- if .Values.commonAnnotations }}
-    {{ .Values.commonAnnotations | toYaml | indent 4 }}
+    {{- toYaml .Values.commonAnnotations | nindent 4 }}
     {{- end }}
 spec:
   type: {{ .Values.service.type }}


### PR DESCRIPTION
# Fix `service.yaml`: render multiple `service.annotations` correctly

## Problem

`charts/xwiki/templates/service.yaml` is broken when `service.annotations` (or `commonAnnotations`) contains more than one key. A single annotation accidentally renders OK because YAML tolerates an over-indented child, but two or more produce invalid YAML and `helm template` / `helm upgrade` fail with:

```
YAML parse error on xwiki/templates/service.yaml:
  error converting YAML to JSON: yaml: line 11: did not find expected key
```

### Reproduce

```yaml
# values.yaml
service:
  annotations:
    foo.example.com/sticky: "true"
    foo.example.com/sticky-name: "sticky"
    foo.example.com/sticky-mode: "lax"
```

```
$ helm template demo .
Error: YAML parse error on xwiki/templates/service.yaml: ...
```

The rendered output (with `helm template --debug`) shows the cause:

```yaml
  annotations:
        foo.example.com/sticky: "true"            # 8 spaces — over-indented
    foo.example.com/sticky-name: sticky           # 4 spaces
    foo.example.com/sticky-mode: lax              # 4 spaces
```

The first key has 8 spaces of indent (4 hardcoded in the template + 4 from `| indent 4`); subsequent keys only get the 4 from `indent 4`. YAML treats them as siblings of different parents → parse fails.

## Root cause

Two template lines have the same bug — `indent N` applied to a line already indented by N literal spaces:

```yaml
{{ .Values.service.annotations | toYaml | indent 4 }}
{{ .Values.commonAnnotations | toYaml | indent 4 }}
```

The literal 4-space prefix is added to the first line of the template output only. `indent 4` adds 4 spaces to *every* line. So the first key ends up with 8.

## Fix

Use `nindent 4` (newline + indent) and strip the literal whitespace with `{{- ... }}`:

```diff
   annotations:
     {{- if .Values.service.annotations }}
-    {{ .Values.service.annotations | toYaml | indent 4 }}
+    {{- toYaml .Values.service.annotations | nindent 4 }}
     {{- end }}
     {{- if .Values.commonAnnotations }}
-    {{ .Values.commonAnnotations | toYaml | indent 4 }}
+    {{- toYaml .Values.commonAnnotations | nindent 4 }}
     {{- end }}
```

`nindent 4` starts with a newline and indents every key by 4 — produces clean YAML for any number of annotations.

## Verified

After the fix, the same reproducer renders:

```yaml
  annotations:
    foo.example.com/sticky: "true"
    foo.example.com/sticky-mode: lax
    foo.example.com/sticky-name: sticky
```

`helm template` and `helm lint` both succeed; `kubectl apply` of the rendered manifest is accepted.

## Why it matters

Any wrapper chart needing service-level annotations (sticky-session cookies for non-NGINX ingress controllers, cloud-provider load-balancer hints, monitoring scrape configs, etc.) currently can't pass more than one annotation through `service.annotations`. The same wrapper-chart pattern works fine on every Bitnami chart and most upstream community charts because they consistently use `nindent`.
