### PR TITLE
fix(kubeping): drop CENTRAL_LOCK and COUNTER for JGroups 5.x compatibility

### DIFF
--- a/charts/xwiki/templates/initialization-configmaps.yaml
+++ b/charts/xwiki/templates/initialization-configmaps.yaml
@@ -144,8 +144,6 @@ data:
         <FRAG2 frag_size="60K"  />
         <!--RSVP resend_interval="2000" timeout="10000"/-->
         <pbcast.STATE_TRANSFER/>
-        <CENTRAL_LOCK />
-        <COUNTER/>
     </config>
   {{- end }}
 


### PR DESCRIPTION
# Fix `initialization-configmaps.yaml`: drop `CENTRAL_LOCK` and `COUNTER` from `kubeping.xml` (incompatible with JGroups 5.x)

## Problem

When `cluster.enabled: true`, the chart renders a `kubeping.xml` file into the `{release}-init-scripts` ConfigMap and the main container copies it into Tomcat's `WEB-INF/observation/remote/jgroups/`. With every recent XWiki LTS image (which ship JGroups 5.x — current image bundles `jgroups-5.5.1.Final.jar`), the JGroups channel **fails to start at boot** and the entire cache-invalidation pathway between cluster nodes is silently broken.

### Pod log

```
ERROR efaultRemoteObservationManager - Failed to start channel [kubeping]
org.xwiki.observation.remote.RemoteEventException: Failed to create channel [kubeping]
    at org.xwiki.observation.remote.internal.jgroups.JGroupsNetworkAdapter.startChannel(...)
...
Caused by: java.lang.Exception: JGRP000002: unable to load protocol CENTRAL_LOCK
  (either with relative - CENTRAL_LOCK - or absolute - org.jgroups.protocols.CENTRAL_LOCK - class name)
    at org.jgroups.util.Util.loadProtocolClass(Util.java:3436)
    at org.jgroups.conf.ProtocolConfiguration.loadProtocolClass(...)
    at org.jgroups.stack.Configurator.createLayer(...)
    at org.jgroups.stack.Configurator.createProtocols(...)
```

### User-visible fallout

- Edits saved on pod A do not appear on pod B (or appear inconsistently after refresh) — caches diverge.
- CSRF token mismatches: a token issued by pod A is rejected on a request handled by pod B.
- `observation.remote.enabled=true` is honoured but the channel never starts, so the `LocalEventListener` is never wired to a working `JGroupsNetworkChannel`.

## Root cause

The hardcoded JGroups protocol stack in `templates/initialization-configmaps.yaml` ends with two protocols that no longer exist in JGroups 5.x:

```xml
<pbcast.STATE_TRANSFER/>
<CENTRAL_LOCK />
<COUNTER/>
```

| Protocol | Status in JGroups 5.x |
|---|---|
| `CENTRAL_LOCK` | **Removed** in JGroups 5.0.0 — replaced by `CENTRAL_LOCK2` (`org.jgroups.protocols.CENTRAL_LOCK2`) |
| `COUNTER` | Class path changed / not loadable as `COUNTER` |

JGroups hard-fails channel initialisation when *any* referenced protocol class can't be loaded, so the whole `kubeping` channel aborts even though the failure is at the very last protocol in the stack.

Neither protocol is used by XWiki's `RemoteObservationManager`. They are optional distributed-lock and distributed-counter primitives that the cache-invalidation pathway does not need.

## Fix

```diff
     <pbcast.STATE_TRANSFER/>
-    <CENTRAL_LOCK />
-    <COUNTER/>
 </config>
```

If the distributed-lock feature is ever needed, the JGroups 5.x replacement is `<org.jgroups.protocols.CENTRAL_LOCK2 />`. For cache invalidation alone, the deletion is sufficient.

## Verified

After the fix, both pods log:

```
GMS: address=xwiki-pod-0-12345, cluster=event, physical address=10.42.1.10:7800
INFO  .o.r.i.j.JGroupsNetworkAdapter - Channel [kubeping] started
```

…and form a working `cluster=event` view over TCP 7800. Edits made on either pod immediately invalidate the other's caches.

## Reproduction

Any 2-replica `cluster.enabled: true` deployment with a current XWiki LTS image (e.g. `xwiki:lts-postgres-tomcat`) on Kubernetes hits this. No special configuration is needed — the bundled JGroups version is enough.

## Why it matters

`cluster.enabled: true` is unusable out-of-the-box on **every** modern XWiki LTS image. Until this lands, multi-replica deployments either (a) silently run with broken cross-pod cache invalidation, or (b) require an out-of-band patch to the rendered ConfigMap.

Chart users currently have no in-chart workaround — `customConfigs` only writes property files (not XML), and `extraVolumes` cannot reliably override a file that the main container's `start.sh` `cp`s over after volume mounts.
