### PR TITLE
fix(solr): make pod fsGroup and init container runAsUser/runAsGroup v…

### DIFF
--- a/charts/xwiki/templates/solr-statefulset.yaml
+++ b/charts/xwiki/templates/solr-statefulset.yaml
@@ -41,8 +41,8 @@ spec:
               mountPath: /tmp/cores
               subPath: data
           securityContext:
-            runAsGroup: 1001
-            runAsUser: 1001
+            runAsGroup: {{ .Values.solr.securityContext.fsGroup }}
+            runAsUser: {{ .Values.solr.securityContext.fsGroup }}
           args:
             - |
               SOLR_CORE_URL="https://maven.xwiki.org/releases/org/xwiki/platform/xwiki-platform-search-solr-server-core/15.5/xwiki-platform-search-solr-server-core-15.5.jar"
@@ -93,8 +93,9 @@ spec:
           volumeMounts:
             - name: xwiki-solr-data
               mountPath: /var/solr/
-      securityContext:
-        fsGroup: 1001
+      {{- if .Values.solr.securityContext.enabled }}
+      securityContext: {{- omit .Values.solr.securityContext "enabled" | toYaml | nindent 8 }}
+      {{- end }}
     {{- with .Values.solr.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/xwiki/values.yaml
+++ b/charts/xwiki/values.yaml
@@ -306,6 +306,12 @@ solr:
     runAsNonRoot: true
     seccompProfile:
       type: RuntimeDefault
+  # Pod-level fsGroup, also applied to the download-cores init container's
+  # runAsUser/runAsGroup so it can write into the fsGroup-owned cores dir.
+  # Mirrors the top-level securityContext.fsGroup convention.
+  securityContext:
+    enabled: true
+    fsGroup: 1001
   service:
     annotations: {}
     portName: solr-node


### PR DESCRIPTION
…alues-driven

Solr's statefulset hardcoded fsGroup/runAsUser/runAsGroup to 1001 with no .Values reference, unlike every other security-sensitive setting in this chart (see the top-level securityContext/containerSecurityContext, and solr.containerSecurityContext). This adds solr.securityContext (enabled + fsGroup), mirroring that existing convention, so environments whose Solr image runs under a different UID/GID don't have to fork the template.

Default (enabled: true, fsGroup: 1001) reproduces prior behavior exactly.